### PR TITLE
Use 'Current' alias to keep Ruby version updated

### DIFF
--- a/Support/bin/groovymate.rb
+++ b/Support/bin/groovymate.rb
@@ -1,4 +1,4 @@
-#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
+#!/System/Library/Frameworks/Ruby.framework/Versions/Current/usr/bin/ruby
 
 require ENV["TM_SUPPORT_PATH"] + "/lib/tm/executor"
 require ENV["TM_SUPPORT_PATH"] + "/lib/tm/save_current_document"


### PR DESCRIPTION
Bundle does not work out of the box with OS X 10.10, because Yosemite ships w/ 2.0 as the default (see related ticket [here](https://github.com/Homebrew/homebrew/issues/29795)). Switching this to use the ‘Current’ alias will circumvent this problem.
