### PR TITLE
Add the standard bundle license to the README

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -7,3 +7,14 @@ You can install this bundle in TextMate by opening the preferences and going to 
 * [Bundle Styleguide](http://kb.textmate.org/bundle_styleguide) — _before you make changes_
 * [Commit Styleguide](http://kb.textmate.org/commit_styleguide) — _before you send a pull request_
 * [Writing Bug Reports](http://kb.textmate.org/writing_bug_reports) — _before you report an issue_
+
+# License
+
+If not otherwise specified (see below), files in this repository fall under the following license:
+
+	Permission to copy, use, modify, sell and distribute this
+	software is granted. This software is provided "as is" without
+	express or implied warranty, and with no claim as to its
+	suitability for any purpose.
+
+An exception is made for files in readable text which contain their own license information, or files where an accompanying file exists (in the same directory) with a “-license” suffix added to the base-name name of the original file, and an extension of txt, html, or similar. For example “tidy” is accompanied by “tidy-license.txt”.


### PR DESCRIPTION
This is the same license used by the other bundles under the textmate organization.
