### PR TITLE
Fix capturing in multi-lined regexp

### DIFF
--- a/Syntaxes/Groovy.tmLanguage
+++ b/Syntaxes/Groovy.tmLanguage
@@ -1600,7 +1600,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>/(?=[^/]+/([^&gt;]|$))</string>
+					<string>/(?=[^/]+([^&gt;]|$))</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>0</key>


### PR DESCRIPTION
Fix the following condition in multi-lined regexp:

- Able to capture:

    ```groovy
    ~/multi-lined[\/]
        regexp/
    ```

- But failed to capture:

    ```groovy
    ~/multi-lined
        regexp/
    ```